### PR TITLE
chore: migrate release workflow to Sampo

### DIFF
--- a/.sampo/changesets/migrate-to-sampo.md
+++ b/.sampo/changesets/migrate-to-sampo.md
@@ -1,0 +1,5 @@
+---
+npm/astro-gravatar: patch
+---
+
+Migrate release workflow to Sampo

--- a/MIGRATION_SUMMARY.md
+++ b/MIGRATION_SUMMARY.md
@@ -1,0 +1,41 @@
+# Migration Complete
+
+The release workflow has been successfully migrated to use Sampo.
+
+## Deliverables
+
+### 1. Sampo Integration
+- **Initialized**: `.sampo/` directory created with `config.toml`.
+- **Configured**:
+  - Main branch: `main`
+  - Repository: `imjlk/astro-gravatar`
+  - Unpublished packages ignored (including docs site).
+  - Release branches: `beta`, `alpha`.
+- **Scripts**: Added `changeset`, `changeset:pre`, `release:prepare` to `package.json`.
+
+### 2. Workflow Automation
+- **Workflow File**: `.github/workflows/release.yml` fully rewritten.
+- **Triggers**:
+  - Merged PRs to `main` (Release PR model).
+  - Pushes to `beta` / `alpha` (Pre-releases).
+- **Steps**:
+  - Standard test gates maintained.
+  - `sampo release` prepares versions/changelogs.
+  - `npm publish` used with provenance (workaround for Bun limitations).
+  - Git tagging and GitHub Release creation automated.
+
+### 3. Documentation
+- **README.md** updated with:
+  - New "Creating Changesets" guide.
+  - Explanation of Release PR workflow.
+  - Bot installation instructions.
+
+## Next Steps for You
+
+1. **Install GitHub App**: Go to [https://github.com/apps/sampo](https://github.com/apps/sampo) and install the bot on this repository.
+2. **First Release**:
+   - Run `bun run changeset` to create a changeset for this migration.
+   - Commit and push.
+   - Merge the PR.
+   - Sampo will create a "Release PR".
+   - Merge the Release PR to trigger the first automated release.


### PR DESCRIPTION
## Summary

Migrate the release workflow from conventional commit-based releases to Sampo for automated changelogs, versioning, and publishing.

### Changes

- **Added Sampo configuration** (`.sampo/config.toml`)
  - Configured for main branch releases and pre-release branches (beta, alpha)
  - Ignored `apps/astro-gravatar.and.guide` from publishing
- **Updated release workflow** (`.github/workflows/release.yml`)
  - Triggers on PR merge to main, or push to beta/alpha
  - Uses `bruits/sampo-github-action@v1` for automated releases
  - Preserved OIDC support with `npm publish --provenance`
- **Added npm scripts** (`package.json`)
  - `changeset` - Add changesets interactively
  - `changeset:pre` - Create pre-release branches
  - `release:prepare` - Prepare release summary
- **Updated documentation** (`README.md`)
  - New "Deployment & Release Workflow" section
  - Instructions for creating changesets
  - Pre-release workflow documentation

### What happens after this PR is merged

1. ✅ This PR contains a changeset that will trigger `v0.0.15` release
2. 🔑 You need to install the [Samo GitHub App](https://github.com/apps/sampo) manually
3. 🤖 GitHub Action will:
   - Generate changelog based on changesets
   - Bump version
   - Create git tag
   - Publish to npm with provenance

### Required Action

Before merging this PR, please:
1. Install [Samo GitHub App](https://github.com/apps/sampo) for this repository
2. Configure the app with appropriate permissions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Migrated release automation to Sampo-based system for streamlined release management.

* **Documentation**
  * Added guidance on creating changesets for release tracking.
  * Documented the release PR workflow and bot integration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->