### PR TITLE
fix: use correct Sampo GitHub Action path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,56 +53,12 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
-      - name: Sampo Release
-        uses: bruits/sampo-github-action@v1
+      - name: Sampo Release & Publish
+        id: sampo
+        uses: bruits/sampo/crates/sampo-github-action@main
         with:
-          command: release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Check for changes
-        id: changes
-        run: |
-          if [[ -n $(git status --porcelain) ]]; then
-            echo "changed=true" >> $GITHUB_OUTPUT
-          else
-            echo "changed=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Commit Changes
-        if: steps.changes.outputs.changed == 'true'
-        run: |
-          git add .
-          git commit -m "chore(release): publish [skip ci]"
-
-      - name: Publish to npm
-        if: steps.changes.outputs.changed == 'true'
-        run: |
-          # Configure OIDC
-          echo "//registry.npmjs.org/:token_type=oidc" >> ~/.npmrc
-          
-          # Publish with npm (for provenance support which Bun lacks)
-          npm publish -w packages/astro-gravatar --provenance --access public --ignore-scripts
-
-      - name: Tag and Push
-        if: steps.changes.outputs.changed == 'true'
-        run: |
-          VERSION=$(jq -r .version packages/astro-gravatar/package.json)
-          echo "VERSION=$VERSION" >> $GITHUB_ENV
-          
-          git tag -a "v$VERSION" -m "Release v$VERSION"
-          # Push to the ref that triggered the workflow (e.g. main, beta)
-          git push origin HEAD:${{ github.ref_name || 'main' }} --follow-tags
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Create GitHub Release
-        if: steps.changes.outputs.changed == 'true'
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: v${{ env.VERSION }}
-          generate_release_notes: true
-          draft: false
-          prerelease: ${{ contains(env.VERSION, '-') }}
+          command: auto
+          create-github-release: true
+          args: --provenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fix the release workflow by using the correct Sampo GitHub Action path and simplifying the workflow.

### Changes

- **Fixed Action Path**: Changed from `bruits/sampo-github-action@v1` (non-existent) to `bruits/sampo/crates/sampo-github-action@main`
- **Simplified Workflow**: Let Sampo Action's `auto` mode handle:
  - Versioning and changelog generation
  - Git tagging
  - Publishing to npm
  - GitHub Release creation
- **Removed Manual Steps**: No longer need separate steps for:
  - Checking for changes
  - Manual git commits
  - Manual npm publish
  - Manual git tagging and pushing
- **Provenance Support**: Added `--provenance` flag via `args` input

### Benefits

- Simpler, more maintainable workflow
- Automatic handling of versioning and publishing
- Single source of truth for release process
- Proper npm provenance support

After this PR merges, the first release (v0.0.15) will be triggered automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow infrastructure to streamline the release and publishing process with improved automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->