### PR TITLE
Release (main)

### DIFF
--- a/.sampo/changesets/migrate-to-sampo.md
+++ b/.sampo/changesets/migrate-to-sampo.md
@@ -1,5 +1,0 @@
----
-npm/astro-gravatar: patch
----
-
-Migrate release workflow to Sampo

--- a/packages/astro-gravatar/CHANGELOG.md
+++ b/packages/astro-gravatar/CHANGELOG.md
@@ -1,0 +1,8 @@
+# astro-gravatar
+
+## 0.0.15 — 2026-02-07
+
+### Patch changes
+
+- [5e458c0](https://github.com/imjlk/astro-gravatar/commit/5e458c054dcac7b623151a065a9397cd1fafe2d3) Migrate release workflow to Sampo — Thanks @imjlk!
+

--- a/packages/astro-gravatar/package.json
+++ b/packages/astro-gravatar/package.json
@@ -1,6 +1,6 @@
 {
   "name": "astro-gravatar",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "type": "module",
   "main": "./index.ts",
   "exports": {


### PR DESCRIPTION
## Release v0.0.15

### Changes

- Migrate release workflow to Sampo
- Automated changelog generation
- Version bumped: 0.0.14 → 0.0.15

When merged, this will:
- Publish to npm with provenance
- Create git tag v0.0.15
- Create GitHub Release