### PR TITLE
fix: Sampo workflow configuration

### DIFF
--- a/.changesets/fix-publish-workflow.md
+++ b/.changesets/fix-publish-workflow.md
@@ -1,0 +1,5 @@
+---
+npm/astro-gravatar: patch
+---
+
+Fix Sampo workflow configuration and add OIDC support for publishing.

--- a/.sampo/changesets/fix-publish-workflow.md
+++ b/.sampo/changesets/fix-publish-workflow.md
@@ -1,0 +1,5 @@
+---
+npm/astro-gravatar: patch
+---
+
+Fix Sampo workflow configuration and add OIDC support for publishing.


### PR DESCRIPTION
## Summary

Fix Sampo workflow configuration and add OIDC support for publishing.

### Changes

- **Sampo workflow updates** (`release.yml`)
  - Change command from `auto` to `release` to only prepare releases
  - Create GitHub Release with version bump and changelog
- **OIDC publishing workflow** (`publish.yml`)
  - Add workflow triggered by `v*` tags
  - Configure OIDC permissions for npm publishing
  - Use Node.js `setup-node` action for npm authentication
- **Fix build issues**
  - Use `bun run build` from package directory

### What happens after this PR merges

1. ✅ Sampo creates a Release PR with version bump (0.0.15 → 0.0.16)
2. 📦 Publish workflow triggers on tag push
3. 🚀 npm publishes automatically with OIDC authentication
4. 📝 GitHub Release is created automatically

### Required Configuration

Before merging, ensure [Trusted Publisher](https://www.npmjs.com/settings/packages/astro-gravatar/publishers) is configured with:
- Organization: `imjlk`
- Repository: `astro-gravatar`
- Workflow filename: `publish.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved publishing workflow reliability for more stable releases.
  * Added OIDC-based publishing support to strengthen release authentication and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->