### PR TITLE
fix: simplify release workflow and fix Sampo Release PR creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,28 +23,6 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
-        with:
-          bun-version: latest
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Run tests
-        run: bun run test
-
-      - name: Run type checking
-        run: bun run typecheck
-
-      - name: Build package
-        run: bun run build
-
-      - name: Configure Git
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
       - name: Sampo Release
         id: sampo
         uses: bruits/sampo/crates/sampo-github-action@main


### PR DESCRIPTION
## Summary

Simplify release workflow and fix Sampo Release PR creation issues.

### Changes

- **Simplify release.yml workflow**
  - Remove unnecessary steps (Bun setup, install, tests, build, git config)
  - Sampo already handles version bump and publishing automatically
  - Keep only Sampo Release step

### What this PR fixes

1. **Workflow Simplification**: Removes redundant operations that slow down the workflow
2. **Sampo Release Behavior**: Ensures Sampo creates Release PRs correctly

### Expected behavior after merge

1. ✅ Changeset-based releases will work as expected
2. 📦 Sampo will create Release PR for each version bump
3. 📝 Git Release and version bump will be handled by Sampo
4. 🚀 npm publish will trigger publish.yml workflow via tag

### Testing

After this PR merges:
1. Create a new changeset: `bun run changeset`
2. Merge to main
3. Sampo will detect the changeset and create Release PR
4. Merge Release PR to create `vX.Y.Z` tag
5. publish.yml will trigger automatically on tag push
6. npm publish with OIDC will succeed