### PR TITLE
ci: add Sampo release workflows, OIDC npm publish, and Sampo bot action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,32 +11,32 @@ permissions:
 
 jobs:
   publish:
-    name: Publish Package
+    name: Publish to npm (OIDC)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Setup Node.js (npm registry)
         uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '22'
           registry-url: 'https://registry.npmjs.org'
-
-      - name: Install Bun (for tests/build)
-        run: |
-          curl -fsSL https://bun.sh/install | bash
-          echo "$HOME/.bun/bin" >> $GITHUB_PATH
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
       - name: Run tests
-        run: bun test
+        run: bun run test
 
       - name: Build package
-        run: cd packages/astro-gravatar && bun run build
+        run: bun run build:package
 
-      - name: Publish to npm
-        run: cd packages/astro-gravatar && npm publish --access public
+      - name: Publish with npm (Trusted Publishing via OIDC)
+        run: npm publish --provenance --access public
         working-directory: packages/astro-gravatar

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Sampo Release
 
 on:
   push:
@@ -14,17 +14,34 @@ permissions:
 
 jobs:
   release:
-    name: Release
+    name: Create/Update Release PR
+    if: github.ref_name == 'main'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sampo Release
-        id: sampo
+        uses: bruits/sampo/crates/sampo-github-action@main
+        with:
+          command: release
+          create-github-release: false
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  prerelease:
+    name: Create pre-release notes
+    if: github.ref_name == 'beta' || github.ref_name == 'alpha'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sampo Pre-release
         uses: bruits/sampo/crates/sampo-github-action@main
         with:
           command: release

--- a/.github/workflows/sampo-bot.yml
+++ b/.github/workflows/sampo-bot.yml
@@ -1,0 +1,22 @@
+name: Sampo Bot
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+jobs:
+  bot:
+    name: Comment changeset guidance
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Sampo GitHub Bot
+        uses: bruits/sampo/crates/sampo-github-bot@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ All PRs that affect the published package should include a changeset file. This 
 bun run changeset
 ```
 
-Alternatively, you can install the [Sampo GitHub App](https://github.com/apps/sampo) to get reminders on your PRs.
+Sampo Bot is now wired through GitHub Actions (`.github/workflows/sampo-bot.yml`) so PRs automatically get changeset reminders and release guidance comments.
 
 ### 2. Release Process (Automated)
 


### PR DESCRIPTION
### Motivation
- Align release automation with Sampo’s Release PR model and enable automated change guidance in PRs. 
- Preserve Bun-first development/test flow while satisfying npm OIDC Trusted Publishing requirements. 
- Provide separate handling for main vs pre-release branches (`beta`/`alpha`) and wire bot guidance into Actions.

### Description
- Reworked `.github/workflows/release.yml` to use the Sampo GH Action (`bruits/sampo/crates/sampo-github-action@main`) and split jobs so `main` creates/updates the Release PR while `beta`/`alpha` create pre-release notes. 
- Rewrote `.github/workflows/publish.yml` to keep Bun for install/test/build but add `actions/setup-node` and run `npm publish --provenance --access public` (OCI/OIDC-friendly) from `packages/astro-gravatar`; the publish job requires `id-token: write`. 
- Added `.github/workflows/sampo-bot.yml` to run the Sampo GitHub Bot on PR and issue comment events so changeset reminders and guidance are provided automatically. 
- Updated `README.md` release section to reflect the new Actions-based Sampo Bot automation and the Sampo-driven release flow.

### Testing
- Ran `bun run test` which executed 472 tests and reported `470 passed` and `2 failed` (both failing tests are in `RequestDeduplicator`: `deduplicate > allows new call after TTL expires` and `edge cases > makes new call after cache expires`). 
- Ran `bun run build:package` which failed in this environment due to a missing `astro` tooling/script error when building the package. 
- Ran `bun install --frozen-lockfile` which failed in this environment due to unresolved `catalog:` dependencies, so full CI reproduction was not possible locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69905f9231148333bbeab1bb1aecdf63)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Updated CI/CD workflows to use OIDC-based trusted publishing for enhanced security.
* Migrated build and test infrastructure to Bun as the package manager.
* Integrated GitHub Actions bot for automated changeset reminders and release guidance.

## Documentation
* Updated README to reflect bot integration through GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->