### PR TITLE
[codex] Automate Sampo release PRs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
   id-token: write
 
 jobs:
@@ -18,7 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       release_branch: ${{ github.ref_name }}
-      should_publish: ${{ steps.release_meta.outputs.should_publish }}
+      released: ${{ steps.sampo.outputs.released }}
+      published: ${{ steps.sampo.outputs.published }}
 
     steps:
       - name: Checkout
@@ -40,91 +42,18 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Resolve release metadata
-        id: release_meta
-        run: |
-          set -euo pipefail
-
-          VERSION="$(node -p "JSON.parse(require('node:fs').readFileSync('packages/astro-gravatar/package.json', 'utf8')).version")"
-          BRANCH="${GITHUB_REF_NAME}"
-
-          case "$BRANCH" in
-            main) DIST_TAG="latest" ;;
-            beta) DIST_TAG="beta" ;;
-            alpha) DIST_TAG="alpha" ;;
-            *)
-              echo "Unsupported release branch: $BRANCH" >&2
-              exit 1
-              ;;
-          esac
-
-          NPM_VERSION="$(npm view astro-gravatar version --tag "$DIST_TAG" 2>/dev/null || true)"
-          TAG_NAME="v$VERSION"
-
-          if git rev-parse "$TAG_NAME" >/dev/null 2>&1; then
-            TAG_EXISTS="true"
-          else
-            TAG_EXISTS="false"
-          fi
-
-          if [ "$VERSION" = "$NPM_VERSION" ]; then
-            SHOULD_PUBLISH="false"
-          else
-            SHOULD_PUBLISH="true"
-          fi
-
-          if [ "$BRANCH" = "main" ]; then
-            PRERELEASE="false"
-          else
-            PRERELEASE="true"
-          fi
-
-          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
-          echo "npm_version=$NPM_VERSION" >> "$GITHUB_OUTPUT"
-          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
-          echo "tag_exists=$TAG_EXISTS" >> "$GITHUB_OUTPUT"
-          echo "should_publish=$SHOULD_PUBLISH" >> "$GITHUB_OUTPUT"
-          echo "prerelease=$PRERELEASE" >> "$GITHUB_OUTPUT"
-
-      - name: No release needed
-        if: steps.release_meta.outputs.should_publish != 'true'
-        run: |
-          echo "npm already has astro-gravatar@${{ steps.release_meta.outputs.version }} for tag ${{ steps.release_meta.outputs.dist_tag }}."
-          echo "Skipping publish."
-
       - name: Run release checks
-        if: steps.release_meta.outputs.should_publish == 'true'
         run: bun run release:check
 
-      - name: Publish to npm
-        if: steps.release_meta.outputs.should_publish == 'true'
-        run: npm publish --provenance --access public --tag "${{ steps.release_meta.outputs.dist_tag }}"
-        working-directory: packages/astro-gravatar
-
-      - name: Create and push git tag
-        if: steps.release_meta.outputs.should_publish == 'true' && steps.release_meta.outputs.tag_exists != 'true'
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a "${{ steps.release_meta.outputs.tag_name }}" -m "Release ${{ steps.release_meta.outputs.tag_name }}"
-          git push origin "${{ steps.release_meta.outputs.tag_name }}"
-
-      - name: Create GitHub release
-        if: steps.release_meta.outputs.should_publish == 'true'
+      - name: Run Sampo release and publish automation
+        id: sampo
+        uses: bruits/sampo/crates/sampo-github-action@sampo-github-action-v0.15.4
+        with:
+          command: auto
+          create-github-release: true
         env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          if gh release view "${{ steps.release_meta.outputs.tag_name }}" >/dev/null 2>&1; then
-            echo "GitHub release already exists for ${{ steps.release_meta.outputs.tag_name }}."
-            exit 0
-          fi
-
-          if [ "${{ steps.release_meta.outputs.prerelease }}" = "true" ]; then
-            gh release create "${{ steps.release_meta.outputs.tag_name }}" --generate-notes --prerelease
-          else
-            gh release create "${{ steps.release_meta.outputs.tag_name }}" --generate-notes
-          fi
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'
 
   deploy_docs:
     name: Deploy docs to Cloudflare Pages

--- a/.github/workflows/upstream-watch.yml
+++ b/.github/workflows/upstream-watch.yml
@@ -34,7 +34,7 @@ jobs:
         run: bun scripts/gravatar-upstream-watch.ts --out /tmp/gravatar-upstream-report.json
 
       - name: Upload upstream report artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7.0.1
         with:
           name: gravatar-upstream-report
           path: /tmp/gravatar-upstream-report.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,11 +90,11 @@ alwaysApply: false
 - CI currently checks lint, formatting, typechecking, coverage, build, security audit, pack dry-run, and bundle size.
 - Docs deployment readiness is checked with `bun run pages:check`, which builds the site and validates the local Wrangler setup without requiring Cloudflare secrets in CI.
 - Coverage enforcement is implemented by `packages/astro-gravatar/package.json` plus `scripts/check-coverage.ts`.
-- `release.yml` is the only release automation workflow. It performs release checks, publishes with npm Trusted Publishing (OIDC), and creates the version tag when npm is behind the committed package version.
+- `release.yml` is the only release automation workflow. It runs Sampo in `auto` mode, prepares or refreshes release PRs from `.sampo/changesets/*.md`, and publishes with npm Trusted Publishing (OIDC) after those release PRs are merged.
 - Changes that affect the published package should usually include a Sampo release entry via `bun run sampo:add`.
 - `sampo-bot.yml` comments on PRs that touch publishable package source without adding a `.sampo/changesets/*.md` file. Use `skip-changeset`, `no-changeset`, or `release:skip` only when a release entry is intentionally unnecessary.
 - npm Trusted Publishing must be configured for `.github/workflows/release.yml`.
-- The operational release sequence is: `bun run release:check` -> `bun run sampo:add` -> optional `bun run sampo:preview` -> `bun run sampo:release` -> review version/changelog -> push the release-prepared commit to `main` -> let `release.yml` publish and create the `v<version>` tag.
+- The operational release sequence is: `bun run release:check` -> `bun run sampo:add` -> optional `bun run sampo:preview` -> merge the feature PR into `main` -> let `release.yml` create or refresh the release PR -> review and merge that release PR -> let `release.yml` publish and create the `v<version>` tag.
 
 ## Documentation expectations
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ bun run pages:deploy:preview
 bun run release:check
 bun run sampo:add
 bun run sampo:preview
-bun run sampo:release
 ```
 
 ## Documentation
@@ -132,21 +131,22 @@ Because Direct Upload ships prebuilt assets, `PUBLIC_GA_MEASUREMENT_ID` must be 
 
 ## Release workflow
 
-This repo uses Bun for local validation, Sampo for release metadata preparation, and a single GitHub Actions workflow for actual npm publishing.
+This repo uses Bun for local validation, Sampo changesets for release intent, and a single GitHub Actions workflow that creates release PRs and publishes after those PRs are merged.
 
 1. Run `bun run release:check`.
 2. Add a Sampo release entry when the published package changes: `bun run sampo:add`.
 3. Run `bun run sampo:preview` if you want to inspect the planned version bump before changing files.
-4. Run `bun run sampo:release` to consume pending release entries and update version/changelog metadata.
-5. Review the resulting package version and `packages/astro-gravatar/CHANGELOG.md`.
-6. Push the release-prepared commit to `main`. `.github/workflows/release.yml` will publish to npm with OIDC when the committed package version is newer than npm, then create the `v<version>` tag automatically.
+4. Merge the feature PR into `main` once checks pass.
+5. `.github/workflows/release.yml` will create or refresh a release PR from the pending `.sampo/changesets/*.md` entries.
+6. Review and merge that release PR. The same workflow then publishes to npm with OIDC, creates tags, and opens GitHub Releases automatically.
 
 ### Workflow responsibilities
 
 - `.github/workflows/release.yml` is the single release automation workflow.
-- It compares the committed package version against the current npm dist-tag, runs release checks, publishes to npm with Trusted Publishing (OIDC), and creates the `v<version>` git tag when needed.
+- It runs Sampo in `auto` mode on `main`, `beta`, and `alpha`, which means it prepares release PRs when changesets exist and publishes after those PRs are merged.
 - npm Trusted Publishing for `astro-gravatar` must point at `.github/workflows/release.yml`.
 - `.github/workflows/sampo-bot.yml` leaves a PR reminder when publishable package source changes without a `.sampo/changesets/*.md` entry. Add `skip-changeset`, `no-changeset`, or `release:skip` when a release entry is intentionally unnecessary.
+- `bun run sampo:release` remains available as a manual escape hatch, but it is no longer the normal path for routine releases.
 
 ### Astro directory listing
 


### PR DESCRIPTION
## Summary
- switch `release.yml` to Sampo `auto` mode so main/beta/alpha prepare release PRs from pending changesets and publish after those PRs are merged
- update repo guidance to describe the release-PR-first flow instead of the old manual `sampo:release` path
- bump the remaining workflow references that could still surface Node 20 runtime warnings

## Validation
- `bun run format:check`
- `bun run pages:check`
- `bun run release:check`
- `cd packages/astro-gravatar && bun pm pack --dry-run`
